### PR TITLE
Prevent endless retry

### DIFF
--- a/src/ensq_topic.erl
+++ b/src/ensq_topic.erl
@@ -398,7 +398,7 @@ http_get(URL) ->
             error
     end.
 
-down_ref(_, Ref, [{_, _, _, Ref, _}], _) ->
+down_ref(_, Ref, [{_, _, _, Ref}], _) ->
     delete;
 down_ref(_, _, [], _) ->
     delete;


### PR DESCRIPTION
I met endless retry of a dead node... logs filled with retries.

Since we fetch info from nsqlookupd periodically and add hosts automatically,
we don't need to retry a node that may never came back.